### PR TITLE
Add FlyWay schemas and describe FlyWay and jOOQ configs in build.gradle

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="postgres@localhost" uuid="598fc066-bbe3-4bd1-9684-003191f62002">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/postgres</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/main-service/build.gradle
+++ b/main-service/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.flywaydb.flyway' version '9.22.3'
+    id 'nu.studer.jooq' version '9.0'
 }
 
 java {
@@ -22,7 +24,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -37,6 +38,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     compileOnly 'org.projectlombok:lombok'
+    jooqGenerator 'org.postgresql:postgresql'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
@@ -44,6 +46,43 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+def profile = System.getProperty('spring.profiles.active', 'dev')
+def props = new Properties()
+file("src/main/resources/application-${profile}.properties").withInputStream {
+    props.load(it)
+}
+
+flyway {
+    url = "${props.get('spring.flyway.url')}"
+    user = "${props.get('spring.flyway.user')}"
+    password = "${props.get('spring.flyway.password')}"
+    locations = "${props.get('spring.flyway.locations')}".split("\\,")
+}
+
+jooq {
+    configurations {
+        main {
+            generateSchemaSourceOnCompilation = false
+            generationTool {
+                jdbc {
+                    driver = "${props.get('spring.datasource.driver-class-name')}"
+                    url = "${props.get('spring.datasource.url')}"
+                    user = "${props.get('spring.datasource.username')}"
+                    password = "${props.get('spring.datasource.password')}"
+                }
+
+                generator {
+                    target {
+                        packageName = 'com.syschallenge.mainservice'
+                        directory = 'build/generated-src/jooq/main'
+                    }
+                    strategy.name = 'org.jooq.codegen.DefaultGeneratorStrategy'
+                }
+            }
+        }
+    }
 }
 
 tasks.named('test') {

--- a/main-service/src/main/resources/db/migration/V0_0_1__UsersSchema.sql
+++ b/main-service/src/main/resources/db/migration/V0_0_1__UsersSchema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS users_table(
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(73) NOT NULL,
+    registered_at TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
With these changes, in the future we will be able to apply migrations first when building an application, then create jOOQ schemas and then compile the application.

We also created a prototype of the user base table