### PR TITLE
Rename methods in UserOccupationController to align with new naming convention

### DIFF
--- a/domain-service/src/main/java/com/syschallenge/user/controller/UserOccupationController.java
+++ b/domain-service/src/main/java/com/syschallenge/user/controller/UserOccupationController.java
@@ -47,8 +47,8 @@ public class UserOccupationController {
      * @return user occupation DTO containing employment details
      */
     @GetMapping("/{id}/occupation")
-    public UserOccupationDto getOccupation(@PathVariable("id") UUID id) {
-        return userOccupationService.getOccupation(id);
+    public UserOccupationDto get(@PathVariable("id") UUID id) {
+        return userOccupationService.get(id);
     }
 
     /**
@@ -60,10 +60,10 @@ public class UserOccupationController {
      * @return created user occupation DTO with persisted data
      */
     @PostMapping("/{id}/occupation")
-    public UserOccupationDto createOccupation(@PathVariable("id") UUID id,
-                                              @RequestBody @Validated CreateOccupationRequest request,
-                                              UsernamePasswordAuthenticationToken auth) {
-        return userOccupationService.createOccupation(id, request, UUID.fromString(auth.getName()));
+    public UserOccupationDto create(@PathVariable("id") UUID id,
+                                    @RequestBody @Validated CreateOccupationRequest request,
+                                    UsernamePasswordAuthenticationToken auth) {
+        return userOccupationService.create(id, request, UUID.fromString(auth.getName()));
     }
 
     /**
@@ -75,10 +75,10 @@ public class UserOccupationController {
      * @return updated user occupation DTO with modified data
      */
     @PutMapping("/{id}/occupation")
-    public UserOccupationDto updateOccupation(@PathVariable("id") UUID id,
-                                              @RequestBody @Validated UpdateOccupationRequest request,
-                                              UsernamePasswordAuthenticationToken auth) {
-        return userOccupationService.updateOccupation(id, request, UUID.fromString(auth.getName()));
+    public UserOccupationDto update(@PathVariable("id") UUID id,
+                                    @RequestBody @Validated UpdateOccupationRequest request,
+                                    UsernamePasswordAuthenticationToken auth) {
+        return userOccupationService.update(id, request, UUID.fromString(auth.getName()));
     }
 
     /**
@@ -88,9 +88,9 @@ public class UserOccupationController {
      * @param auth authentication token containing requester's identity
      */
     @DeleteMapping("/{id}/occupation")
-    public void deleteOccupation(@PathVariable("id") UUID id,
-                                 UsernamePasswordAuthenticationToken auth) {
-        userOccupationService.deleteOccupation(id, UUID.fromString(auth.getName()));
+    public void delete(@PathVariable("id") UUID id,
+                       UsernamePasswordAuthenticationToken auth) {
+        userOccupationService.delete(id, UUID.fromString(auth.getName()));
     }
 
 }

--- a/domain-service/src/main/java/com/syschallenge/user/service/UserOccupationService.java
+++ b/domain-service/src/main/java/com/syschallenge/user/service/UserOccupationService.java
@@ -53,7 +53,7 @@ public class UserOccupationService {
      * @return a DTO containing the got user occupation information
      */
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public UserOccupationDto getOccupation(UUID id) {
+    public UserOccupationDto get(UUID id) {
         return userOccupationToUserOccupationDtoMapper.userOccupationToUserOccupationDto(
                 userOccupationRepository.findByUserId(id)
         );
@@ -69,7 +69,7 @@ public class UserOccupationService {
      * @throws PermissionDeniedException if the user does not have permission to update this occupation
      */
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public UserOccupationDto createOccupation(UUID id, CreateOccupationRequest request, UUID principalId) throws PermissionDeniedException {
+    public UserOccupationDto create(UUID id, CreateOccupationRequest request, UUID principalId) throws PermissionDeniedException {
         if (!id.equals(principalId) && userRepository.findRoleById(principalId).equals(UserRole.DEFAULT)) {
             throw new PermissionDeniedException("You can only create your own occupation.");
         }
@@ -94,7 +94,7 @@ public class UserOccupationService {
      * @throws PermissionDeniedException if the user does not have permission to save this occupation
      */
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public UserOccupationDto updateOccupation(UUID id, UpdateOccupationRequest request, UUID principalId) throws PermissionDeniedException {
+    public UserOccupationDto update(UUID id, UpdateOccupationRequest request, UUID principalId) throws PermissionDeniedException {
         if (!id.equals(principalId) && userRepository.findRoleById(principalId).equals(UserRole.DEFAULT)) {
             throw new PermissionDeniedException("You can only update your own occupation.");
         }
@@ -117,7 +117,7 @@ public class UserOccupationService {
      * @throws PermissionDeniedException if the user does not have permission to delete this occupation
      */
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    public void deleteOccupation(UUID id, UUID principalId) throws PermissionDeniedException {
+    public void delete(UUID id, UUID principalId) throws PermissionDeniedException {
         if (!id.equals(principalId) && userRepository.findRoleById(principalId).equals(UserRole.DEFAULT)) {
             throw new PermissionDeniedException("You can only delete your own occupation.");
         }

--- a/domain-service/src/test/java/com/syschallenge/user/UserOccupationServiceTest.java
+++ b/domain-service/src/test/java/com/syschallenge/user/UserOccupationServiceTest.java
@@ -51,7 +51,7 @@ class UserOccupationServiceTest {
     private UserOccupationService userOccupationService;
 
     @Test
-    void updateOccupation_throwsPermissionDeniedException_whenIdEqualsPrincipalId() {
+    void update_throwsPermissionDeniedException_whenIdEqualsPrincipalId() {
         UUID id = UUID.randomUUID();
         UUID principalId = id;
         UpdateOccupationRequest request = new UpdateOccupationRequest(
@@ -62,12 +62,12 @@ class UserOccupationServiceTest {
         );
 
         PermissionDeniedException exception = assertThrows(PermissionDeniedException.class,
-                () -> userOccupationService.updateOccupation(id, request, principalId));
+                () -> userOccupationService.update(id, request, principalId));
         assertEquals("You can only update your own occupation.", exception.getMessage());
     }
 
     @Test
-    void updateOccupation_updatesAndReturnsUserOccupationDto_whenIdNotEqualToPrincipalId() {
+    void update_updatesAndReturnsUserOccupationDto_whenIdNotEqualToPrincipalId() {
         UUID id = UUID.randomUUID();
         UUID principalId = UUID.randomUUID();
         UpdateOccupationRequest request = new UpdateOccupationRequest(
@@ -99,7 +99,7 @@ class UserOccupationServiceTest {
         when(userOccupationToUserOccupationDtoMapper.userOccupationToUserOccupationDto(updatedOccupation))
                 .thenReturn(expectedDto);
 
-        UserOccupationDto actualDto = userOccupationService.updateOccupation(id, request, principalId);
+        UserOccupationDto actualDto = userOccupationService.update(id, request, principalId);
 
         assertNotNull(actualDto);
         assertEquals(expectedDto, actualDto);


### PR DESCRIPTION
We need this because we migrated UserOccupation into a separate component, but forgot to rename the method conventions for better readability …onvention